### PR TITLE
Configurable through parameter server

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package read_omni_dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.0.3 (2016-09-08)
+* Added launch file to play rosbag files and launch the reader
+* Reader is now customizable via the parameter server (check example launch file)
+* Contibutors: guilhermelawless
+
 0.0.2 (2014-12-11)
 ------------------
 

--- a/launch/all_four_robots.launch
+++ b/launch/all_four_robots.launch
@@ -1,0 +1,22 @@
+<launch>
+    <arg name="path" default="/home/$(optenv USER gsl)/datasets/omni/four_msl_robots_dataset"/>
+    <node
+        pkg="rosbag"
+        type="play"
+        name="player"
+        output="screen"
+        args="-l $(arg path)/OMNI1_odomballLandmarks.bag $(arg path)/OMNI3_odomballLandmarks.bag $(arg path)/OMNI4_odomballLandmarks.bag $(arg path)/OMNI5_odomballLandmarks.bag $(arg path)/four_robot_experiment_GT.bag"
+    />
+
+    <node pkg="read_omni_dataset" type="read_omni_dataset" name="reader" output="screen">
+    	<param name="NUM_ROBOTS" value="5"/>
+    	<param name="MY_ID" value="1"/>
+    	<param name="ROB_HT" type="double" value="0.81"/>
+    	<param name="LANDMARK_COV/K1" type="double" value="2.0"/>
+    	<param name="LANDMARK_COV/K2" type="double" value="0.5"/>
+    	<param name="LANDMARK_COV/K3" type="double" value="0.2"/>
+    	<param name="LANDMARK_COV/K4" type="double" value="0.5"/>
+    	<param name="LANDMARK_COV/K5" type="double" value="0.5"/>
+    </node>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>read_omni_dataset</name>
-  <version>0.0.2</version>
+  <version>0.0.3</version>
   <description>This package is a read module that asynchronously reads messages from the socrob omni dataset. The purpose of this package is to provide a quick and ready-to-start platform for developing and implementing perception related algorithms on the omni dataset</description>
   <maintainer email="aamir.iitkgp@gmail.com">aamir</maintainer>
   <license>GPLv3</license>

--- a/src/read_omni_dataset.cpp
+++ b/src/read_omni_dataset.cpp
@@ -1,12 +1,10 @@
 
 #include "read_omni_dataset.h"
 
-
 inline void addLandmark(int vertexId, double x, double y)
 {
   ROS_INFO("A fixed landmark with ID %d at position x=%f, y=%f must be created in your application, e.g., fixed vertices in a graph if your application is graph-based",vertexId,x,y);
 }
-
 
 void ReadRobotMessages::initializeFixedLandmarks()
 {
@@ -37,7 +35,7 @@ void SelfRobot::selfOdometryCallback(const nav_msgs::Odometry::ConstPtr& odometr
 
   //Below is an example how to extract the odometry from the message and use it to propogate the robot state by simply concatenating successive odometry readings-
   double odomVector[3] = {odometry->pose.pose.position.x, odometry->pose.pose.position.y, tf::getYaw(odometry->pose.pose.orientation)};
-  
+
   Eigen::Isometry2d odom; 
   odom = Eigen::Rotation2Dd(odomVector[2]).toRotationMatrix();
   odom.translation() = Eigen::Vector2d(odomVector[0], odomVector[1]);  
@@ -124,8 +122,6 @@ void SelfRobot::selfLandmarkDataCallback(const read_omni_dataset::LRMLandmarksDa
   }
   
  }
-
- 
 
 ////////////////////////// METHOD DEFINITIONS OF THE TEAMMATEROBOT CLASS //////////////////////
 

--- a/src/read_omni_dataset.h
+++ b/src/read_omni_dataset.h
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <string>
 
-
 #include <nav_msgs/Odometry.h>
 #include <tf/transform_broadcaster.h>
 #include <read_omni_dataset/BallData.h>
@@ -19,9 +18,9 @@
 // #define M_PI        3.141592653589793238462643383280    /* pi */
 
 
-///TODO These hard coded values must go out of this place. Preferably as the arguments of the main function and therefore in the launch file.
+// Most of these values will be read through the parameter server, but a default value is given
 
-const std::size_t NUM_ROBOTS = 5; // total number of robots in the team including self
+std::size_t NUM_ROBOTS = 5; // total number of robots in the team including self
 const std::size_t NUM_SENSORS_PER_ROBOs = 3;// SENSORS include odometry, each feature sensor like a ball detector, each landmark-set detector and so on. In this case for example the number of sensors are 3, 1-odometry, 1-orange ball, 1-landmarkset. Usually this must co-incide with the number of topics to which each robot is publishing its sensed information.
 
 const std::size_t NUM_TARGETS = 1; // Number of targets being tracked. In omni dataset, only one target exists for now: the orange ball. This may be improved in future by adding the blue ball which can be seen the raw footage of the dataset experiment
@@ -30,17 +29,17 @@ const std::size_t NUM_TARGETS = 1; // Number of targets being tracked. In omni d
 
 
 //coefficients for landmark observation covariance
-const std::size_t K1 = 2.0;
-const std::size_t K2 = 0.5;
+std::size_t K1 = 2.0;
+std::size_t K2 = 0.5;
 
 //coefficients for target observation covariance
-const std::size_t K3 = 0.2;
-const std::size_t K4 = 0.5;
-const std::size_t K5 = 0.5; 
-//const float K3 = 0.2, K4 = 0.5, K5 = 0.5; 
+std::size_t K3 = 0.2;
+std::size_t K4 = 0.5;
+std::size_t K5 = 0.5;
+//float K3 = 0.2, K4 = 0.5, K5 = 0.5; 
 
-const std::size_t ROB_HT = 0.81; //(In this dataset) fixed height of the robots above ground in meter
-const std::size_t MY_ID = 1; // Use this flag to set the ID of the robot expected to run a certain decentralized algorithm. Robot with MY_ID will be trated as the self robot running the algorithm while the rest will be considered teammates. Note that in the dataset there are 4 robots with IDs 1,3,4 and 5. Robot with ID=2 is not present.
+std::size_t ROB_HT = 0.81; //(In this dataset) fixed height of the robots above ground in meter
+std::size_t MY_ID = 1; // Use this flag to set the ID of the robot expected to run a certain decentralized algorithm. Robot with MY_ID will be trated as the self robot running the algorithm while the rest will be considered teammates. Note that in the dataset there are 4 robots with IDs 1,3,4 and 5. Robot with ID=2 is not present.
 
 //Initial 2D positons of the robot as obtained from the overhead ground truth system. The order is OMNI1 OMNI2 OMNI3 OMNI4 and OMNI5. Notice OMNI2 is initialized as 0,0 because the robot is absent from the dataset.
 //This initialization will work only if the read_omni_dataset node startes befoe the rosbag of the dataset. Obviously, the initialization below is for the initial positions at the begginning of the dataset. Otherwise, the initialization makes the odometry-only trajecory frame transformed to the origin.
@@ -50,6 +49,20 @@ const double initArray[10] = {5.086676,-2.648978,0.0,0.0,1.688772,-2.095153,3.26
 using namespace ros;
 using namespace std;
 
+template <typename T>
+void readParamDouble(ros::NodeHandle *nh, const std::string name, std::size_t variable){
+
+  double tmp;
+  ostringstream oss;
+  if(nh->getParam(name, tmp))
+  {
+    variable = (T)tmp;
+    oss << "Received parameter " << name << "=" << variable;
+    ROS_INFO("%s", oss.str().c_str());
+  }
+  else
+    ROS_ERROR("Failed to receive parameter %s", name.c_str());
+}
 
 class SelfRobot
 {
@@ -143,10 +156,18 @@ class ReadRobotMessages
   SelfRobot* robot_;
   vector<TeammateRobot*> teammateRobots_;
 
-  
   public:
-    ReadRobotMessages(): loop_rate_(30)
-    { 
+    ReadRobotMessages(): loop_rate_(30), nh_("~")
+    {
+      readParamDouble<int>(&nh_, "NUM_ROBOTS", NUM_ROBOTS);
+      readParamDouble<double>(&nh_, "ROB_HT", ROB_HT);
+      readParamDouble<int>(&nh_, "MY_ID", MY_ID);
+      readParamDouble<double>(&nh_, "LANDMARK_COV/K1", K1);
+      readParamDouble<double>(&nh_, "LANDMARK_COV/K2", K2);
+      readParamDouble<double>(&nh_, "LANDMARK_COV/K3", K3);
+      readParamDouble<double>(&nh_, "LANDMARK_COV/K4", K4);
+      readParamDouble<double>(&nh_, "LANDMARK_COV/K5", K5);
+
       Eigen::Isometry2d initialRobotPose;
       
       teammateRobots_.reserve(NUM_ROBOTS);
@@ -158,11 +179,11 @@ class ReadRobotMessages
 	
 	if(i+1 == MY_ID)
 	{
-	  robot_ = new SelfRobot(&nh_,i, initialRobotPose);
+      robot_ = new SelfRobot(&nh_,i, initialRobotPose);
 	}
 	else
 	{	  
-	  TeammateRobot *tempRobot = new TeammateRobot(&nh_,i, initialRobotPose);
+      TeammateRobot *tempRobot = new TeammateRobot(&nh_,i, initialRobotPose);
 	  teammateRobots_.push_back(tempRobot);
 	}	
       }


### PR DESCRIPTION
Now reads parameters through parameter server
Example launch file added - when launching use 

`roslaunch read_omni_headset all_four_robots.launch path:={YOUR_PATH}`

 Or change the launch file itself.
